### PR TITLE
UserAgent에 따라 단축키 표시 변경 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,6 +407,23 @@ console.log(person);`,
                 });
             }
         }
+        // UserAgent에 따라 단축키 표시 변경
+        const runBtn = document.querySelector(".button-run");
+        const userAgent = navigator.userAgent;
+
+        if (userAgent.includes("Mac OS X")) {
+            runBtn.textContent = "Run Code (Cmd+Enter)";
+            editor.addCommand(
+            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+            runCode
+            );
+        } else {
+            runBtn.textContent = "Run Code (Ctrl+Enter)";
+            editor.addCommand(
+            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+            runCode
+            );
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/b48c9e78-33a4-4be5-a378-84cac38ca230">

UserAgent 값에 따라 macOS 및 iOS 환경에서는 실행 버튼의 단축키 텍스트를 'Ctrl'에서 'Cmd'로 표시되도록 수정했습니다.