### PR TITLE
UserAgent에 따라 단축키 표시 변경 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,6 +407,23 @@ console.log(person);`,
                 });
             }
         }
+        // UserAgent에 따라 단축키 표시 변경
+        const runBtn = document.querySelector(".button-run");
+        const userAgent = navigator.userAgent;
+
+        if (userAgent.includes("Mac OS X")) {
+            runBtn.textContent = "Run Code (Cmd+Enter)";
+            editor.addCommand(
+            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+            runCode
+            );
+        } else {
+            runBtn.textContent = "Run Code (Ctrl+Enter)";
+            editor.addCommand(
+            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+            runCode
+            );
+        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -413,16 +413,8 @@ console.log(person);`,
 
         if (userAgent.includes("Mac OS X")) {
             runBtn.textContent = "Run Code (Cmd+Enter)";
-            editor.addCommand(
-            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-            runCode
-            );
         } else {
             runBtn.textContent = "Run Code (Ctrl+Enter)";
-            editor.addCommand(
-            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-            runCode
-            );
         }
     </script>
 </body>


### PR DESCRIPTION
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/438b5f2a-6d37-4a54-b3cd-3f554d3441c2">

UserAgent에 따라 macOS 및 iOS 환경에서 실행 버튼의 단축키 설명을 Ctrl에서 Cmd로 표시되도록 수정했습니다.